### PR TITLE
Add open graph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ breakdown of the settings you can customize:
 | Setting           | Description
 |------------------ | -------------------------------------------------
 | smallSize         | Maximum size for small thumbnails 
-| mediumSize        | Maximum size for medium thumbnails 
+| mediumSize        | Maximum size for medium thumbnails
+| baseUrl           | Base URL
 | refreshInterval   | How often photos are refreshed (e.g 10s, 15m, 1h)
 | title             | Title of the portfolio
+| description       | Description used in [Open Graph](https://ogp.me/) meta tags (social media preview)
 | author            | Author of the photos
 | about             | Text for the `About` page. HTML tags are allowed
 

--- a/main.go
+++ b/main.go
@@ -27,24 +27,28 @@ var photos []photo.Photo = make([]photo.Photo, 0)
 var appSettings *settings.AppSettings
 
 type TemplateData struct {
-	Photos     []photo.Photo
-	Year       int
-	Title      string
-	Author     string
-	About      template.HTML
-	SmallSize  int
-	MediumSize int
+	Photos      []photo.Photo
+	Year        int
+	Title       string
+	Description string
+	Author      string
+	About       template.HTML
+	SmallSize   int
+	MediumSize  int
+	BaseURL     string
 }
 
 func getTemplateData() TemplateData {
 	return TemplateData{
-		Photos:     photos,
-		Year:       time.Now().Year(),
-		Title:      appSettings.Title,
-		Author:     appSettings.Author,
-		About:      template.HTML(appSettings.About),
-		SmallSize:  appSettings.SmallSize,
-		MediumSize: appSettings.MediumSize,
+		Photos:      photos,
+		Year:        time.Now().Year(),
+		Title:       appSettings.Title,
+		Description: appSettings.Description,
+		Author:      appSettings.Author,
+		About:       template.HTML(appSettings.About),
+		SmallSize:   appSettings.SmallSize,
+		MediumSize:  appSettings.MediumSize,
+		BaseURL:     appSettings.BaseURL,
 	}
 }
 

--- a/settings.yaml.sample
+++ b/settings.yaml.sample
@@ -1,7 +1,9 @@
 smallSize: 200
 mediumSize: 750
 refreshInterval: 10m
+baseUrl: http://localhost
 title: Portfolio
+description: Description used in Open Graph description
 author: Your name
 about: >
   <p>Write something about yourself here.</p>

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -17,6 +18,8 @@ func ReadSettings() (*AppSettings, error) {
 	if err := yaml.Unmarshal(data, &appSettings); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings.yaml: %v", err)
 	}
+
+	appSettings.BaseURL = strings.TrimSuffix(appSettings.BaseURL, "/")
 
 	return &appSettings, nil
 }

--- a/settings/types.go
+++ b/settings/types.go
@@ -6,7 +6,9 @@ type AppSettings struct {
 	SmallSize       int           `yaml:"smallSize"`
 	MediumSize      int           `yaml:"mediumSize"`
 	RefreshInterval time.Duration `yaml:"refreshInterval"`
+	BaseURL         string        `yaml:"baseUrl" default:""`
 	Title           string        `yaml:"title"`
+	Description     string        `yaml:"description" default:""`
 	Author          string        `yaml:"author"`
 	About           string        `yaml:"about"`
 }

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -8,6 +8,13 @@
     <link rel="stylesheet" href="static/style.css" />
     <link rel="stylesheet" href="static/custom.css" />
     <link rel="alternate" type="application/atom+xml" title="RSS feed" href="/feed" />
+    {{ if and (ne .BaseURL "") (ne .Title "") (gt (len .Photos) 0) }}
+    <meta property="og:title" content="{{ .Title }}" />
+    <meta property="og:description" content="{{ .Description }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ .BaseURL }}" />
+    <meta property="og:image" content="{{ .BaseURL }}/photo/{{ (index .Photos 0).MediumFileName }}" />
+    {{ end }}
 </head>
 <body>
     <div id="container">


### PR DESCRIPTION
Remember to add `description` and `baseUrl` settings to your `settings.yaml` file. Otherwise the template does not render open graph meta tags.